### PR TITLE
FetchUseCase 정의

### DIFF
--- a/Tempus/Data/CoreDataRepository.swift
+++ b/Tempus/Data/CoreDataRepository.swift
@@ -98,7 +98,7 @@ extension CoreDataRepository {
 
 // MARK: - Fetch Method
 extension CoreDataRepository {
-    func fetchAllTimerEntity() throws -> [TimerEntity] {
+    func fetchAllTimerModel() throws -> [TimerModel] {
         let context = container.viewContext
         let fetchRequest = TimerEntity.fetchRequest()
         
@@ -106,7 +106,9 @@ extension CoreDataRepository {
         
         do {
             let result = try context.fetch(fetchRequest)
-            return result
+            return result.map { entity in
+                entity.toModel
+            }
         } catch {
             #if DEBUG
             print(error)
@@ -116,7 +118,7 @@ extension CoreDataRepository {
         }
     }
     
-    func fetchAllBlockEntity() throws -> [BlockEntity] {
+    func fetchAllBlockModel() throws -> [BlockModel] {
         let context = container.viewContext
         let fetchRequest = BlockEntity.fetchRequest()
         
@@ -124,7 +126,9 @@ extension CoreDataRepository {
         
         do {
             let result = try context.fetch(fetchRequest) as [BlockEntity]
-            return result
+            return result.map { entity in
+                entity.toModel
+            }
         } catch {
             #if DEBUG
             print(error)
@@ -134,7 +138,7 @@ extension CoreDataRepository {
         }
     }
     
-    func fetchAllDailyEntity() throws -> [DailyEntity] {
+    func fetchAllDailyModel() throws -> [DailyModel] {
         let context = container.viewContext
         let fetchRequest = DailyEntity.fetchRequest()
         
@@ -142,7 +146,9 @@ extension CoreDataRepository {
         
         do {
             let result = try context.fetch(fetchRequest) as [DailyEntity]
-            return result
+            return result.map { entity in
+                entity.toModel
+            }
         } catch {
             #if DEBUG
             print(error)

--- a/Tempus/Domain/Entity/Block/BlockEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Block/BlockEntity+CoreDataProperties.swift
@@ -18,7 +18,7 @@ extension BlockEntity {
 
     @NSManaged public var divideCount: Int16
     @NSManaged public var createdAt: Double
-    @NSManaged public var uuid: UUID?
+    @NSManaged public var uuid: UUID
     @NSManaged public var title: String
 
 }

--- a/Tempus/Domain/Entity/Block/BlockEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Block/BlockEntity+CoreDataProperties.swift
@@ -16,11 +16,16 @@ extension BlockEntity {
         return NSFetchRequest<BlockEntity>(entityName: "BlockEntity")
     }
 
-    @NSManaged public var divideCount: Int16
+    @NSManaged public var divideCount: Int
     @NSManaged public var createdAt: Double
     @NSManaged public var uuid: UUID
     @NSManaged public var title: String
 
+    var toModel: BlockModel {
+        return BlockModel(id: uuid,
+                          title: title,
+                          divideCount: divideCount)
+    }
 }
 
 extension BlockEntity : Identifiable {

--- a/Tempus/Domain/Entity/Daily/DailyEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Daily/DailyEntity+CoreDataProperties.swift
@@ -17,9 +17,9 @@ extension DailyEntity {
     }
 
     @NSManaged public var title: String
-    @NSManaged public var uuid: UUID?
+    @NSManaged public var uuid: UUID
     @NSManaged public var startTime: Double
-    @NSManaged public var repeatCount: Int16
+    @NSManaged public var repeatCount: Int
     @NSManaged public var focusTime: Double
     @NSManaged public var breakTime: Double
     @NSManaged public var createdAt: Double

--- a/Tempus/Domain/Entity/Daily/DailyEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Daily/DailyEntity+CoreDataProperties.swift
@@ -24,6 +24,14 @@ extension DailyEntity {
     @NSManaged public var breakTime: Double
     @NSManaged public var createdAt: Double
 
+    var toModel: DailyModel {
+        return DailyModel(id: uuid,
+                          title: title,
+                          startTime: startTime,
+                          repeatCount: repeatCount,
+                          focusTime: focusTime,
+                          breakTime: breakTime)
+    }
 }
 
 extension DailyEntity : Identifiable {

--- a/Tempus/Domain/Entity/Tempus.xcdatamodeld/Tempus.xcdatamodel/contents
+++ b/Tempus/Domain/Entity/Tempus.xcdatamodeld/Tempus.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="createdAt" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="divideCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
-        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="DailyEntity" representedClassName="DailyEntity" syncable="YES">
         <attribute name="breakTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
@@ -13,7 +13,7 @@
         <attribute name="repeatCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
-        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="TimerEntity" representedClassName="TimerEntity" syncable="YES">
         <attribute name="createdAt" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>

--- a/Tempus/Domain/Entity/Timer/TimerEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Timer/TimerEntity+CoreDataProperties.swift
@@ -17,7 +17,7 @@ extension TimerEntity {
     }
 
     @NSManaged public var wasteTime: Double
-    @NSManaged public var uuid: UUID?
+    @NSManaged public var uuid: UUID
     @NSManaged public var title: String
     @NSManaged public var createdAt: Double
 

--- a/Tempus/Domain/Entity/Timer/TimerEntity+CoreDataProperties.swift
+++ b/Tempus/Domain/Entity/Timer/TimerEntity+CoreDataProperties.swift
@@ -20,7 +20,12 @@ extension TimerEntity {
     @NSManaged public var uuid: UUID
     @NSManaged public var title: String
     @NSManaged public var createdAt: Double
-
+    
+    var toModel: TimerModel {
+        return TimerModel(id: uuid,
+                          title: title,
+                          wasteTime: wasteTime)
+    }
 }
 
 extension TimerEntity : Identifiable {

--- a/Tempus/Domain/Model/BlockModel.swift
+++ b/Tempus/Domain/Model/BlockModel.swift
@@ -10,13 +10,5 @@ import Foundation
 struct BlockModel {
     let id: UUID
     var title: String
-    var divideCount: Double
-    var toEntity: BlockEntity {
-        let entity = BlockEntity()
-        entity.uuid = id
-        entity.title = title
-        entity.divideCount = Int16(divideCount)
-        
-        return entity
-    }
+    var divideCount: Int
 }

--- a/Tempus/Domain/Model/DailyModel.swift
+++ b/Tempus/Domain/Model/DailyModel.swift
@@ -14,16 +14,4 @@ struct DailyModel {
     var repeatCount: Int
     var focusTime: Double
     var breakTime: Double
-    var toEntity: DailyEntity {
-        let entity = DailyEntity()
-        
-        entity.uuid = id
-        entity.title = title
-        entity.startTime = startTime
-        entity.repeatCount = repeatCount
-        entity.focusTime = focusTime
-        entity.breakTime = breakTime
-        
-        return entity
-    }
 }

--- a/Tempus/Domain/Model/DailyModel.swift
+++ b/Tempus/Domain/Model/DailyModel.swift
@@ -20,7 +20,7 @@ struct DailyModel {
         entity.uuid = id
         entity.title = title
         entity.startTime = startTime
-        entity.repeatCount = Int16(repeatCount)
+        entity.repeatCount = repeatCount
         entity.focusTime = focusTime
         entity.breakTime = breakTime
         

--- a/Tempus/Domain/Model/TimerModel.swift
+++ b/Tempus/Domain/Model/TimerModel.swift
@@ -11,12 +11,4 @@ struct TimerModel {
     let id: UUID
     var title: String
     var wasteTime: Double
-    var toEntity: TimerEntity {
-        let entity = TimerEntity()
-        entity.uuid = id
-        entity.title = title
-        entity.wasteTime = wasteTime
-        
-        return entity
-    }
 }

--- a/Tempus/Domain/Repository/DataManagerRepository.swift
+++ b/Tempus/Domain/Repository/DataManagerRepository.swift
@@ -12,9 +12,9 @@ protocol DataManagerRepository {
     func create(model: BlockModel) throws
     func create(model: DailyModel) throws
     
-    func fetchAllTimerEntity() throws -> [TimerEntity]
-    func fetchAllBlockEntity() throws -> [BlockEntity]
-    func fetchAllDailyEntity() throws -> [DailyEntity]
+    func fetchAllTimerModel() throws -> [TimerModel]
+    func fetchAllBlockModel() throws -> [BlockModel]
+    func fetchAllDailyModel() throws -> [DailyModel]
     
     func update(_ model: TimerModel) throws
     func update(_ model: BlockModel) throws

--- a/Tempus/Domain/UseCase/Block/BlockFetchUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockFetchUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  BlockFetchUseCase.swift
+//  Tempus
+//
+//  Created by 이정민 on 2023/04/18.
+//
+
+import Foundation
+
+final class BlockFetchUseCase {
+    let repository: DataManagerRepository
+    
+    init(repository: DataManagerRepository) {
+        self.repository = repository
+    }
+    
+    func execute(_ completion: @escaping ([BlockModel]) -> Void) throws {
+        let models = try repository.fetchAllBlockModel()
+        
+        completion(models)
+    }
+}

--- a/Tempus/Domain/UseCase/Block/BlockStartUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockStartUseCase.swift
@@ -74,10 +74,10 @@ final class BlockStartUseCase {
         timer = nil
     }
     
-    private func generateSchedule(divideCount: Double) -> [Date] {
+    private func generateSchedule(divideCount: Int) -> [Date] {
         let calendar = Calendar.current
         let now = Date()
-        let interval = 24 / divideCount
+        let interval = Double(24 / divideCount)
         let oneDaySecond = 24.0 * 60.0 * 60.0
         let oneHourSecond = 60.0 * 60.0
         

--- a/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
+++ b/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  DailyFetchUseCase.swift
+//  Tempus
+//
+//  Created by 이정민 on 2023/04/18.
+//
+
+import Foundation
+
+final class DailyFetchUseCase {
+    let repository: DataManagerRepository
+    
+    init(repository: DataManagerRepository) {
+        self.repository = repository
+    }
+    
+    func execute(_ completion: @escaping ([DailyModel]) -> Void) throws {
+        let entities = try repository.fetchAllDailyEntity()
+        let models = transform(entities: entities)
+        
+        completion(models)
+    }
+    
+    private func transform(entities: [DailyEntity]) -> [DailyModel] {
+        return entities.map { entity in
+            DailyModel(id: entity.uuid,
+                       title: entity.title,
+                       startTime: entity.startTime,
+                       repeatCount: entity.repeatCount,
+                       focusTime: entity.focusTime,
+                       breakTime: entity.breakTime)
+        }
+    }
+}

--- a/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
+++ b/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
@@ -15,20 +15,8 @@ final class DailyFetchUseCase {
     }
     
     func execute(_ completion: @escaping ([DailyModel]) -> Void) throws {
-        let entities = try repository.fetchAllDailyEntity()
-        let models = transform(entities: entities)
+        let models = try repository.fetchAllDailyModel()
         
         completion(models)
-    }
-    
-    private func transform(entities: [DailyEntity]) -> [DailyModel] {
-        return entities.map { entity in
-            DailyModel(id: entity.uuid,
-                       title: entity.title,
-                       startTime: entity.startTime,
-                       repeatCount: entity.repeatCount,
-                       focusTime: entity.focusTime,
-                       breakTime: entity.breakTime)
-        }
     }
 }

--- a/TempusTests/BlockUseCaseTests/BlockCreateUseCaseTest.swift
+++ b/TempusTests/BlockUseCaseTests/BlockCreateUseCaseTest.swift
@@ -20,7 +20,7 @@ final class BlockCreateUseCaseTest: XCTestCase {
         // Arrange
         let id = UUID()
         let title = "testTitle"
-        let divideCount = Double(6)
+        let divideCount = 6
         let model = BlockModel(id: id, title: title, divideCount: divideCount)
         
         // Act, Assert

--- a/TempusTests/BlockUseCaseTests/BlockDeleteUseCaseTest.swift
+++ b/TempusTests/BlockUseCaseTests/BlockDeleteUseCaseTest.swift
@@ -22,7 +22,7 @@ final class BlockDeleteUseCaseTest: XCTestCase {
         // Arrange
         let id = UUID()
         let title = "testTitle"
-        let divideCount = Double(6)
+        let divideCount = 6
         let model = BlockModel(id: id, title: title, divideCount: divideCount)
         try! blockCreateUseCase.execute(model: model) {}
         

--- a/TempusTests/BlockUseCaseTests/BlockEditUseCaseTest.swift
+++ b/TempusTests/BlockUseCaseTests/BlockEditUseCaseTest.swift
@@ -23,7 +23,7 @@ final class BlockEditUseCaseTest: XCTestCase {
         let id = UUID()
         let title = "testTitle"
         let changeTitle = "changeTitle"
-        let divideCount = Double(6)
+        let divideCount = 6
         var model = BlockModel(id: id, title: title, divideCount: divideCount)
         try! blockCreateUseCase.execute(model: model) {}
         

--- a/TempusTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
+++ b/TempusTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
@@ -1,0 +1,39 @@
+//
+//  BlockFetchUseCaseTest.swift
+//  TempusTests
+//
+//  Created by 이정민 on 2023/04/18.
+//
+
+import XCTest
+
+final class BlockFetchUseCaseTest: XCTestCase {
+    var blockCreateUseCase: BlockCreateUseCase!
+    var blockFetchUseCase: BlockFetchUseCase!
+    var coreDataRepositoryMock: DataManagerRepositoryMock!
+    
+    override func setUpWithError() throws {
+        coreDataRepositoryMock = DataManagerRepositoryMock()
+        blockCreateUseCase = BlockCreateUseCase(repository: coreDataRepositoryMock)
+        blockFetchUseCase = BlockFetchUseCase(repository: coreDataRepositoryMock)
+    }
+    
+    func test_Block_fetch_is_success() {
+        // Arrange
+        let id = UUID()
+        let title = "testTitle"
+        let divideCount = 6
+        let model = BlockModel(id: id, title: title, divideCount: divideCount)
+        
+        try! blockCreateUseCase.execute(model: model) {}
+        
+        // Act, Assert
+        do {
+            try blockFetchUseCase.execute { models in
+                XCTAssertEqual(models.first!.id, id)
+            }
+        } catch {
+            XCTFail()
+        }
+    }
+}

--- a/TempusTests/BlockUseCaseTests/BlockStartUseCaseTest.swift
+++ b/TempusTests/BlockUseCaseTests/BlockStartUseCaseTest.swift
@@ -1,5 +1,5 @@
 //
-//  BlockStartUseCaseTests.swift
+//  BlockStartUseCaseTest.swift
 //  TempusTests
 //
 //  Created by 이정민 on 2023/04/10.

--- a/TempusTests/BlockUseCaseTests/BlockStartUseCaseTests.swift
+++ b/TempusTests/BlockUseCaseTests/BlockStartUseCaseTests.swift
@@ -47,10 +47,10 @@ class BlockStartUseCaseTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
     
-    final private func generateSchedule(divideCount: Double) -> [Date] {
+    final private func generateSchedule(divideCount: Int) -> [Date] {
         let calendar = Calendar.current
         let now = Date()
-        let interval = 24 / divideCount
+        let interval = Double(24 / divideCount)
         let oneDaySecond = 24.0 * 60.0 * 60.0
         let oneHourSecond = 60.0 * 60.0
         

--- a/TempusTests/CoreDataRepositoryTests/CoreDataRepositoryTests.swift
+++ b/TempusTests/CoreDataRepositoryTests/CoreDataRepositoryTests.swift
@@ -90,7 +90,7 @@ extension CoreDataRepositoryTests {
         let uuid = UUID()
         let testTitle = "testTitle"
         let divideCount = 4
-        let model = BlockModel(id: uuid, title: testTitle, divideCount: Double(divideCount))
+        let model = BlockModel(id: uuid, title: testTitle, divideCount: divideCount)
         
         // Act, Assert
         do {
@@ -114,10 +114,10 @@ extension CoreDataRepositoryTests {
         
         // Act, Assert
         do {
-            let result = try repository.fetchAllTimerEntity()
+            let result = try repository.fetchAllTimerModel()
             let object = result.first!
             
-            XCTAssertEqual(uuid, object.uuid)
+            XCTAssertEqual(uuid, object.id)
         } catch {
             XCTFail()
         }

--- a/TempusTests/DailyUseCaseTests/DailyFetchUseCaseTests.swift
+++ b/TempusTests/DailyUseCaseTests/DailyFetchUseCaseTests.swift
@@ -8,28 +8,40 @@
 import XCTest
 
 final class DailyFetchUseCaseTests: XCTestCase {
-
+    var dailyCreateUseCase: DailyCreateUseCase!
+    var dailyFetchUseCase: DailyFetchUseCase!
+    var coreDataRepositoryMock: DataManagerRepositoryMock!
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        coreDataRepositoryMock = DataManagerRepositoryMock()
+        dailyCreateUseCase = DailyCreateUseCase(repository: coreDataRepositoryMock)
+        dailyFetchUseCase = DailyFetchUseCase(repository: coreDataRepositoryMock)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    
+    func test_Daily_fetch_is_success() {
+        // Arrange
+        let id = UUID()
+        let title = "testTitle"
+        let startTime: Double = 123456
+        let repeatCount: Int = 4
+        let focusTime: Double = 123456789
+        let breakTime: Double = 123456789
+        let model = DailyModel(id: id,
+                               title: title,
+                               startTime: startTime,
+                               repeatCount: repeatCount,
+                               focusTime: focusTime,
+                               breakTime: breakTime)
+        
+        try! dailyCreateUseCase.execute(model: model) {}
+        
+        // Act, Assert
+        do {
+            try dailyFetchUseCase.execute { models in
+                XCTAssertEqual(models.first!.id, id)
+            }
+        } catch {
+            XCTFail()
         }
     }
-
 }

--- a/TempusTests/DailyUseCaseTests/DailyFetchUseCaseTests.swift
+++ b/TempusTests/DailyUseCaseTests/DailyFetchUseCaseTests.swift
@@ -1,0 +1,35 @@
+//
+//  DailyFetchUseCaseTests.swift
+//  TempusTests
+//
+//  Created by 이정민 on 2023/04/18.
+//
+
+import XCTest
+
+final class DailyFetchUseCaseTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/TempusTests/Mock/DataManagerRepositoryMock.swift
+++ b/TempusTests/Mock/DataManagerRepositoryMock.swift
@@ -24,16 +24,16 @@ class DataManagerRepositoryMock: DataManagerRepository {
         dailyModel = model
     }
     
-    func fetchAllTimerEntity() throws -> [TimerEntity] {
-        return timerModel != nil ? [timerModel!.toEntity] : []
+    func fetchAllTimerModel() throws -> [TimerModel] {
+        return [timerModel!]
     }
     
-    func fetchAllBlockEntity() throws -> [BlockEntity] {
-        return blockModel != nil ? [blockModel!.toEntity] : []
+    func fetchAllBlockModel() throws -> [BlockModel] {
+        return [blockModel!]
     }
     
-    func fetchAllDailyEntity() throws -> [DailyEntity] {
-        return dailyModel != nil ? [dailyModel!.toEntity] : []
+    func fetchAllDailyModel() throws -> [DailyModel] {
+        return [dailyModel!]
     }
     
     func update(_ model: TimerModel) throws {


### PR DESCRIPTION
Closed #53 

### 구현내용
- BlockFetchUseCase
- DailyFetchUseCase

- repository 의 fetch 메서드 수정. Entity를 반환하는 것이 아닌 Model을 반환. 
  - realm을 사용하게되는 경우 Entity는 coredata관련이라 모르기 때문

- entity에서 Model로 변환하는 기능
```swift
extension TimerEntity {

    @nonobjc public class func fetchRequest() -> NSFetchRequest<TimerEntity> {
        return NSFetchRequest<TimerEntity>(entityName: "TimerEntity")
    }

    @NSManaged public var wasteTime: Double
    @NSManaged public var uuid: UUID
    @NSManaged public var title: String
    @NSManaged public var createdAt: Double
    
    var toModel: TimerModel {
        return TimerModel(id: uuid,
                          title: title,
                          wasteTime: wasteTime)
    }
}
```
entity 타입이 각각 연산프로퍼티를 통해 가지도록 했는데
엔티티가 무언가 기능을 가지는게 적절치 않아보여서 transformer 타입을 만들어 사용하고 싶었으나

transform이라는 메서드가 오버로딩되어 3개가 생김.
일반화를 하고 싶었는데 아직 generic 사용이 익숙치 않아 이후 리팩토링예정

### 필수체크
- [x] 정상적인 빌드
- [x] 단위테스트 