### PR TITLE
DailyListViewModel 정의

### DIFF
--- a/Tempus/Domain/UseCase/Block/BlockCreateUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockCreateUseCase.swift
@@ -11,15 +11,13 @@ import RxSwift
 
 final class BlockCreateUseCase {
     struct Input {
-        let modelFetchEvent: PublishSubject<Void>
         let modelCreate: Observable<BlockModel>
     }
     
     struct Output {
-        let isCreateSuccess: PublishSubject<Bool>
+        let isCreateSuccess: PublishSubject<Bool> = .init()
     }
     
-    private let isCreateSuccess: PublishSubject<Bool> = .init()
     private let repository: DataManagerRepository
     
     init(repository: DataManagerRepository) {
@@ -27,30 +25,25 @@ final class BlockCreateUseCase {
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output(isCreateSuccess: isCreateSuccess)
+        let output = Output()
         
-        bind(input, disposeBag, isCreateSuccess)
+        input.modelCreate
+            .subscribe(onNext: { [weak self] model in
+                guard let self else { return }
+                do {
+                    try self.execute(model: model) {
+                        output.isCreateSuccess.onNext(true)
+                    }
+                } catch {
+                    output.isCreateSuccess.onNext(false)
+                }
+            }).disposed(by: disposeBag)
         
         return output
     }
 }
 
 private extension BlockCreateUseCase {
-    func bind(_ input: Input, _ disposeBag: DisposeBag, _ isCreateSuccess: PublishSubject<Bool>) {
-        input.modelCreate
-            .subscribe(onNext: { [weak self] model in
-                guard let self else { return }
-                do {
-                    try self.execute(model: model) {
-                        input.modelFetchEvent.onNext(())
-                        isCreateSuccess.onNext(true)
-                    }
-                } catch {
-                    isCreateSuccess.onNext(false)
-                }
-            }).disposed(by: disposeBag)
-    }
-    
     func execute(model: BlockModel, _ completion: @escaping () -> Void) throws {
         try repository.create(model)
         completion()

--- a/Tempus/Domain/UseCase/Block/BlockDeleteUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockDeleteUseCase.swift
@@ -10,24 +10,32 @@ import RxSwift
 final class BlockDeleteUseCase {
     struct Input {
         let modelDeleteEvent: Observable<BlockModel>
-        let modelFetchEvent: PublishSubject<Void>
     }
     
     struct Output {
-        let isDeleteSuccess: PublishSubject<Bool>
+        let isDeleteSuccess: PublishSubject<Bool> = .init()
     }
     
     private let repository: DataManagerRepository
-    private let isDeleteSuccess: PublishSubject<Bool> = .init()
     
     init(repository: DataManagerRepository) {
         self.repository = repository
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output(isDeleteSuccess: isDeleteSuccess)
+        let output = Output()
         
-        bind(input: input, disposeBag: disposeBag)
+        input.modelDeleteEvent
+            .subscribe(onNext: { [weak self] model in
+                guard let self else { return }
+                do {
+                    try self.execute(model: model) {
+                        output.isDeleteSuccess.onNext(true)
+                    }
+                } catch {
+                    output.isDeleteSuccess.onNext(false)
+                }
+            }).disposed(by: disposeBag)
         
         return output
     }
@@ -37,20 +45,5 @@ private extension BlockDeleteUseCase {
     func execute(model: BlockModel, _ completion: @escaping () -> Void) throws {
         try repository.delete(model)
         completion()
-    }
-    
-    func bind(input: Input, disposeBag: DisposeBag) {
-        input.modelDeleteEvent
-            .subscribe(onNext: { [weak self] model in
-                guard let self else { return }
-                do {
-                    try self.execute(model: model) {
-                        self.isDeleteSuccess.onNext(true)
-                        input.modelFetchEvent.onNext(())
-                    }
-                } catch {
-                    self.isDeleteSuccess.onNext(false)
-                }
-            }).disposed(by: disposeBag)
     }
 }

--- a/Tempus/Domain/UseCase/Block/BlockDeleteUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockDeleteUseCase.swift
@@ -25,23 +25,28 @@ final class BlockDeleteUseCase {
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        input.modelDeleteEvent
-            .subscribe(onNext: { [weak self] model in
-                guard let self else { return }
-                do {
-                    try self.execute(model: model) {
-                        output.isDeleteSuccess.onNext(true)
-                    }
-                } catch {
-                    output.isDeleteSuccess.onNext(false)
-                }
-            }).disposed(by: disposeBag)
+        bindModelDeleteEvent(input.modelDeleteEvent, to: output.isDeleteSuccess, disposeBag: disposeBag)
         
         return output
     }
 }
 
 private extension BlockDeleteUseCase {
+    func bindModelDeleteEvent(_ modelDeleteEvent: Observable<BlockModel>, to isDeleteSuccess: PublishSubject<Bool>, disposeBag: DisposeBag) {
+        modelDeleteEvent
+            .subscribe(onNext: { [weak self] model in
+                guard let self else { return }
+                do {
+                    try self.execute(model: model) {
+                        isDeleteSuccess.onNext(true)
+                    }
+                } catch {
+                    isDeleteSuccess.onNext(false)
+                }
+            }).disposed(by: disposeBag)
+    }
+    
+    
     func execute(model: BlockModel, _ completion: @escaping () -> Void) throws {
         try repository.delete(model)
         completion()

--- a/Tempus/Domain/UseCase/Block/BlockEditUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockEditUseCase.swift
@@ -15,10 +15,9 @@ final class BlockEditUseCase {
     }
     
     struct Output {
-        let isEditSuccess: PublishSubject<Bool>
+        let isEditSuccess: PublishSubject<Bool> = .init()
     }
     
-    private let isEditSuccess: PublishSubject<Bool> = .init()
     private let repository: DataManagerRepository
     
     init(repository: DataManagerRepository) {
@@ -26,25 +25,30 @@ final class BlockEditUseCase {
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output(isEditSuccess: isEditSuccess)
+        let output = Output()
         
-        input.modelEditEvent
-            .subscribe(onNext: { [weak self] model in
-                guard let self else { return }
-                do {
-                    try self.execute(model: model) {
-                        self.isEditSuccess.onNext(true)
-                    }
-                } catch {
-                    self.isEditSuccess.onNext(false)
-                }
-            }).disposed(by: disposeBag)
+        bindModelEditEvent(input.modelEditEvent, to: output.isEditSuccess, disposeBag: disposeBag)
         
         return output
     }
 }
 
 private extension BlockEditUseCase {
+    func bindModelEditEvent(_ editEvent: Observable<BlockModel>,
+                            to isEditSuccess: PublishSubject<Bool>,
+                            disposeBag: DisposeBag) {
+        editEvent
+            .subscribe(onNext: { model in
+                do {
+                    try self.execute(model: model) {
+                        isEditSuccess.onNext(true)
+                    }
+                } catch {
+                    isEditSuccess.onNext(false)
+                }
+            }).disposed(by: disposeBag)
+    }
+    
     func execute(model: BlockModel, _ completion: @escaping () -> Void) throws {
         try repository.update(model)
         completion()

--- a/Tempus/Domain/UseCase/Block/BlockEditUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockEditUseCase.swift
@@ -12,7 +12,6 @@ import RxSwift
 final class BlockEditUseCase {
     struct Input {
         let modelEditEvent: Observable<BlockModel>
-        let modelFetchEvent: PublishSubject<Void>
     }
     
     struct Output {
@@ -35,7 +34,6 @@ final class BlockEditUseCase {
                 do {
                     try self.execute(model: model) {
                         self.isEditSuccess.onNext(true)
-                        input.modelFetchEvent.onNext(())
                     }
                 } catch {
                     self.isEditSuccess.onNext(false)

--- a/Tempus/Domain/UseCase/Block/BlockFetchUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockFetchUseCase.swift
@@ -25,12 +25,22 @@ final class BlockFetchUseCase {
     func transform(input: Input, disposeBag: DisposeBag) -> OutPut {
         let output = OutPut()
         
-        input.modelFetchEvent
+        bindModelFetchEvent(input.modelFetchEvent,
+                            to: output.modelArrayObservable,
+                            disposeBag: disposeBag)
+        
+        return output
+    }
+}
+
+private extension BlockFetchUseCase {
+    func bindModelFetchEvent(_ modelFetchEvent: Observable<Void>, to modelArrayObservable: PublishSubject<[BlockModel]>, disposeBag: DisposeBag) {
+        modelFetchEvent
             .subscribe(onNext: { [weak self] _ in
                 guard let self else { return }
                 do {
                     try self.execute { models in
-                        output.modelArrayObservable.onNext(models)
+                        modelArrayObservable.onNext(models)
                     }
                 } catch {
 //                    self.modelArrayObservable.onError(error)
@@ -38,12 +48,8 @@ final class BlockFetchUseCase {
                 }
             })
             .disposed(by: disposeBag)
-        
-        return output
     }
-}
-
-private extension BlockFetchUseCase {
+    
     func execute(_ completion: @escaping ([BlockModel]) -> Void) throws {
         let models = try repository.fetchAllBlockModel()
         completion(models)

--- a/Tempus/Domain/UseCase/Block/BlockStartUseCase.swift
+++ b/Tempus/Domain/UseCase/Block/BlockStartUseCase.swift
@@ -39,25 +39,32 @@ final class BlockStartUseCase: ModeStartUseCase {
     override func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output(remainTime: timeObservable,
                             modeState: modeStateObservable)
-
-        input.modeStartEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStart()
-            }).disposed(by: disposeBag)
-
-        input.modeStopEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStop()
-            }).disposed(by: disposeBag)
+        
+        bindModeStartEvent(input.modeStartEvent, disposeBag: disposeBag)
+        bindModeStopEvent(input.modeStopEvent, disposeBag: disposeBag)
 
         return output
     }
 }
 
 private extension BlockStartUseCase {
-    private func modeStart() {
+    func bindModeStartEvent(_ modeStartEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStartEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStart()
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindModeStopEvent(_ modeStopEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStopEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStop()
+            }).disposed(by: disposeBag)
+    }
+    
+    func modeStart() {
         guard timer == nil else { return }
         
         /* Noti enroll */
@@ -90,12 +97,12 @@ private extension BlockStartUseCase {
         RunLoop.current.add(timer!, forMode: .default)
     }
     
-    private func modeStop() {
+    func modeStop() {
         timer?.invalidate()
         timer = nil
     }
     
-    private func generateSchedule(divideCount: Int) -> [Date] {
+    func generateSchedule(divideCount: Int) -> [Date] {
         let calendar = Calendar.current
         let now = Date()
         let interval = Double(24 / divideCount)

--- a/Tempus/Domain/UseCase/Daily/DailyDeleteUseCase.swift
+++ b/Tempus/Domain/UseCase/Daily/DailyDeleteUseCase.swift
@@ -5,12 +5,47 @@
 //  Created by 이정민 on 2023/04/02.
 //
 
+import RxSwift
+
 final class DailyDeleteUseCase {
-    let repository: DataManagerRepository
+    struct Input {
+        let modelDeleteEvent: Observable<DailyModel>
+    }
+    
+    struct Output {
+        let isDeleteSuccess: PublishSubject<Bool> = .init()
+    }
+    
+    private let repository: DataManagerRepository
     
     init(repository: DataManagerRepository) {
         self.repository = repository
     }
+    
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        bindModelDeleteEvent(input.modelDeleteEvent, to: output.isDeleteSuccess, disposeBag: disposeBag)
+        
+        return output
+    }
+}
+
+private extension DailyDeleteUseCase {
+    func bindModelDeleteEvent(_ modelDeleteEvent: Observable<DailyModel>, to isDeleteSuccess: PublishSubject<Bool>, disposeBag: DisposeBag) {
+        modelDeleteEvent
+            .subscribe(onNext: { [weak self] model in
+                guard let self else { return }
+                do {
+                    try self.execute(model: model) {
+                        isDeleteSuccess.onNext(true)
+                    }
+                } catch {
+                    isDeleteSuccess.onNext(false)
+                }
+            }).disposed(by: disposeBag)
+    }
+    
     
     func execute(model: DailyModel, _ completion: @escaping () -> Void) throws {
         try repository.delete(model)

--- a/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
+++ b/Tempus/Domain/UseCase/Daily/DailyFetchUseCase.swift
@@ -5,16 +5,53 @@
 //  Created by 이정민 on 2023/04/18.
 //
 
+import RxSwift
+
 final class DailyFetchUseCase {
-    let repository: DataManagerRepository
+    struct Input {
+        let modelFetchEvent: Observable<Void>
+    }
+    
+    struct OutPut {
+        let modelArrayObservable: PublishSubject<[DailyModel]> = .init()
+    }
+    
+    private let repository: DataManagerRepository
     
     init(repository: DataManagerRepository) {
         self.repository = repository
     }
     
+    func transform(input: Input, disposeBag: DisposeBag) -> OutPut {
+        let output = OutPut()
+        
+        bindModelFetchEvent(input.modelFetchEvent,
+                            to: output.modelArrayObservable,
+                            disposeBag: disposeBag)
+        
+        return output
+    }
+}
+
+private extension DailyFetchUseCase {
+    func bindModelFetchEvent(_ modelFetchEvent: Observable<Void>, to modelArrayObservable: PublishSubject<[DailyModel]>, disposeBag: DisposeBag) {
+        modelFetchEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self else { return }
+                do {
+                    try self.execute { models in
+                        modelArrayObservable.onNext(models)
+                    }
+                } catch {
+//                    self.modelArrayObservable.onError(error)
+                    return
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
     func execute(_ completion: @escaping ([DailyModel]) -> Void) throws {
         let models = try repository.fetchAllDailyModel()
-        
         completion(models)
     }
 }

--- a/Tempus/Domain/UseCase/Daily/DailyStartUseCase.swift
+++ b/Tempus/Domain/UseCase/Daily/DailyStartUseCase.swift
@@ -39,23 +39,30 @@ final class DailyStartUseCase: ModeStartUseCase {
         let output = Output(remainTime: timeObservable,
                             modeState: modeStateObservable)
 
-        input.modeStartEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStart()
-            }).disposed(by: disposeBag)
-
-        input.modeStopEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStop()
-            }).disposed(by: disposeBag)
+        bindModeStartEvent(input.modeStartEvent, disposeBag: disposeBag)
+        bindModeStopEvent(input.modeStopEvent, disposeBag: disposeBag)
 
         return output
     }
 }
 
 private extension DailyStartUseCase {
+    func bindModeStartEvent(_ modeStartEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStartEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStart()
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindModeStopEvent(_ modeStopEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStopEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStop()
+            }).disposed(by: disposeBag)
+    }
+    
     func modeStart() {
         guard timer == nil else { return }
         

--- a/Tempus/Domain/UseCase/Timer/TimerStartUseCase.swift
+++ b/Tempus/Domain/UseCase/Timer/TimerStartUseCase.swift
@@ -36,24 +36,31 @@ final class TimerStartUseCase: ModeStartUseCase {
     override func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output(remainTime: timeObservable,
                             modeState: modeStateObservable)
-
-        input.modeStartEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStart()
-            }).disposed(by: disposeBag)
-
-        input.modeStopEvent
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.modeStop()
-            }).disposed(by: disposeBag)
+        
+        bindModeStartEvent(input.modeStartEvent, disposeBag: disposeBag)
+        bindModeStopEvent(input.modeStopEvent, disposeBag: disposeBag)
 
         return output
     }
 }
 
 private extension TimerStartUseCase {
+    func bindModeStartEvent(_ modeStartEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStartEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStart()
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindModeStopEvent(_ modeStopEvent: Observable<Void>, disposeBag: DisposeBag) {
+        modeStopEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.modeStop()
+            }).disposed(by: disposeBag)
+    }
+    
     func modeStart() {
         guard timer == nil else { return }
 

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockCreateViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockCreateViewModel.swift
@@ -40,16 +40,12 @@ final class BlockCreateViewModel {
         let createUseCaseOutput = createUseCase.transform(input: createUseCaseInput,
                                                           disposeBag: disposeBag)
         
-        createUseCaseOutput.isCreateSuccess
-            .subscribe(onNext: { [self] isCreateSuccess in
-                if isCreateSuccess {
-                    self.fetchRefreshDelegate?.refresh()
-                }
-                
-                output.isCreateSuccess.accept(isCreateSuccess)
-            }).disposed(by: disposeBag)
-        
-        bind(input, disposeBag)
+        bindCreateSuccess(createUseCaseOutput.isCreateSuccess,
+                          to: output.isCreateSuccess,
+                          disposeBag)
+        bindModelTitle(input.modelTitle, disposeBag)
+        bindDivideCount(input.divideCount, disposeBag)
+        bindCompleteEvent(input.completeEvent, disposeBag)
         
         return output
     }
@@ -59,20 +55,24 @@ final class BlockCreateViewModel {
 }
 
 private extension BlockCreateViewModel {
-    func bind(_ input: Input, _ disposeBag: DisposeBag) {
-        input.modelTitle
+    func bindModelTitle(_ modelTitle: Observable<String>, _ disposeBag: DisposeBag) {
+        modelTitle
             .subscribe(onNext: { [weak self] title in
                 guard let self else { return }
                 self.modelTitle = title
             }).disposed(by: disposeBag)
-        
-        input.divideCount
+    }
+    
+    func bindDivideCount(_ divideCount: Observable<Int>, _ disposeBag: DisposeBag) {
+        divideCount
             .subscribe(onNext: { [weak self] divideCount in
                 guard let self else { return }
                 self.divideCount = divideCount
             }).disposed(by: disposeBag)
-        
-        input.completeEvent
+    }
+    
+    func bindCompleteEvent(_ completeEvent: Observable<CompleteAlert>, _ disposeBag: DisposeBag) {
+        completeEvent
             .subscribe(onNext: { [weak self] completeAlert in
                 guard let self = self,
                       let title = self.modelTitle,
@@ -95,6 +95,20 @@ private extension BlockCreateViewModel {
                     /* coordinaotr just finish */
                     
                 }
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindCreateSuccess(_ isCreateSuccess: Observable<Bool>,
+                           to isCreateSuccessRelay: PublishRelay<Bool>,
+                           _ disposeBag: DisposeBag) {
+        isCreateSuccess
+            .subscribe(onNext: { [weak self] isCreateSuccess in
+                guard let self = self else { return }
+                if isCreateSuccess {
+                    self.fetchRefreshDelegate?.refresh()
+                }
+                
+                isCreateSuccessRelay.accept(isCreateSuccess)
             }).disposed(by: disposeBag)
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
@@ -20,17 +20,10 @@ final class BlockDetailViewModel {
         let originModelSubject: BehaviorSubject<BlockModel>
     }
     
-    private var originModel: BlockModel {
-        didSet {
-            self.originModelSubject.onNext(originModel)
-        }
-    }
-    
     private let originModelSubject: BehaviorSubject<BlockModel>
     
     init(originModel: BlockModel) {
         self.originModelSubject = .init(value: originModel)
-        self.originModel = originModel
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
@@ -38,8 +31,10 @@ final class BlockDetailViewModel {
         
         input.startButtonTapEvent
             .subscribe(onNext: { [weak self] in
-                guard let self else { return }
-                let startUseCase = BlockStartUseCase(originModel: self.originModel)
+                guard let self,
+                      let originModel = try? self.originModelSubject.value() else { return }
+                
+                let startUseCase = BlockStartUseCase(originModel: originModel)
                 // coordinator push with startUseCase
             }).disposed(by: disposeBag)
         
@@ -62,7 +57,7 @@ final class BlockDetailViewModel {
 extension BlockDetailViewModel: EditReflectDelegate {
     func reflect(_ model: Mode) {
         if let model = model as? BlockModel {
-            self.originModel = model
+            self.originModelSubject.onNext(model)
         }
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
@@ -17,29 +17,24 @@ final class BlockDetailViewModel {
     }
     
     struct Output {
-        let modelTitle: PublishSubject<String>
-        let divideCount: PublishSubject<Int>
+        let originModelSubject: BehaviorSubject<BlockModel>
     }
     
     private var originModel: BlockModel {
         didSet {
-            self.modelTitle.onNext(originModel.title)
-            self.modelDivideCount.onNext(originModel.divideCount)
+            self.originModelSubject.onNext(originModel)
         }
     }
     
-    private let modelTitle: PublishSubject<String>
-    private let modelDivideCount: PublishSubject<Int>
+    private let originModelSubject: BehaviorSubject<BlockModel>
     
     init(originModel: BlockModel) {
-        self.modelTitle = .init()
-        self.modelDivideCount = .init()
+        self.originModelSubject = .init(value: originModel)
         self.originModel = originModel
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output(modelTitle: modelTitle,
-                            divideCount: modelDivideCount)
+        let output = Output(originModelSubject: originModelSubject)
         
         input.startButtonTapEvent
             .subscribe(onNext: { [weak self] in

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
@@ -29,26 +29,9 @@ final class BlockDetailViewModel {
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output(originModelSubject: originModelSubject)
         
-        input.startButtonTapEvent
-            .subscribe(onNext: { [weak self] in
-                guard let self,
-                      let originModel = try? self.originModelSubject.value() else { return }
-                
-                let startUseCase = BlockStartUseCase(originModel: originModel)
-                // coordinator push with startUseCase
-            }).disposed(by: disposeBag)
-        
-        input.editButtonTapEvent
-            .subscribe(onNext: { [weak self] in
-                guard let self else { return }
-                // coordinator push with originModel
-                // and push with self and refresh with edited Data
-            }).disposed(by: disposeBag)
-        
-        input.cancelButtonTapEvent
-            .subscribe(onNext: {
-                // coordinator finish
-            }).disposed(by: disposeBag)
+        bindStartButtonTapEvent(input.startButtonTapEvent, disposeBag)
+        bindEditButtonTapEvent(input.editButtonTapEvent, disposeBag)
+        bindCancelButtonTapEvent(input.cancelButtonTapEvent, disposeBag)
         
         return output
     }
@@ -59,5 +42,34 @@ extension BlockDetailViewModel: EditReflectDelegate {
         if let model = model as? BlockModel {
             self.originModelSubject.onNext(model)
         }
+    }
+}
+
+private extension BlockDetailViewModel {
+    func bindStartButtonTapEvent(_ startEvent: Observable<Void>, _ disposeBag: DisposeBag) {
+        startEvent
+            .subscribe(onNext: { [weak self] in
+                guard let self,
+                      let originModel = try? self.originModelSubject.value() else { return }
+                
+                let startUseCase = BlockStartUseCase(originModel: originModel)
+                // coordinator push with startUseCase
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindEditButtonTapEvent(_ EditEvent: Observable<Void>, _ disposeBag: DisposeBag) {
+        EditEvent
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                // coordinator push with originModel
+                // and push with self and refresh with edited Data
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindCancelButtonTapEvent(_ CancelEvent: Observable<Void>, _ disposeBag: DisposeBag) {
+        CancelEvent
+            .subscribe(onNext: {
+                // coordinator finish
+            }).disposed(by: disposeBag)
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockDetailViewModel.swift
@@ -5,8 +5,6 @@
 //  Created by 이정민 on 2023/04/25.
 //
 
-import Foundation
-
 import RxSwift
 
 final class BlockDetailViewModel {
@@ -37,14 +35,6 @@ final class BlockDetailViewModel {
     }
 }
 
-extension BlockDetailViewModel: EditReflectDelegate {
-    func reflect(_ model: Mode) {
-        if let model = model as? BlockModel {
-            self.originModelSubject.onNext(model)
-        }
-    }
-}
-
 private extension BlockDetailViewModel {
     func bindStartButtonTapEvent(_ startEvent: Observable<Void>, _ disposeBag: DisposeBag) {
         startEvent
@@ -71,5 +61,13 @@ private extension BlockDetailViewModel {
             .subscribe(onNext: {
                 // coordinator finish
             }).disposed(by: disposeBag)
+    }
+}
+
+extension BlockDetailViewModel: EditReflectDelegate {
+    func reflect(_ model: Mode) {
+        if let model = model as? BlockModel {
+            self.originModelSubject.onNext(model)
+        }
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
@@ -45,7 +45,9 @@ final class BlockEditViewModel {
                                                            disposeBag: disposeBag)
         let output = Output(isEditSuccess: editUSeCaseOutput.isEditSuccess)
         
-        bind(input: input, disposeBag: disposeBag)
+        bindModelTitle(input.modelTitle, disposeBag)
+        bindDivideCount(input.modelDivideCount, disposeBag)
+        bindCompleteEvent(input.completeButtonTapEvent, disposeBag)
         
         editUSeCaseOutput.isEditSuccess
             .subscribe(onNext: { [weak self] isSuccess in
@@ -61,20 +63,24 @@ final class BlockEditViewModel {
 }
 
 private extension BlockEditViewModel {
-    func bind(input: Input, disposeBag: DisposeBag) {
-        input.modelTitle
+    func bindModelTitle(_ modelTitle: Observable<String>, _ disposeBag: DisposeBag) {
+        modelTitle
             .subscribe(onNext: { [weak self] modelTitle in
                 guard let self else { return }
                 self.modelTitle = modelTitle
             }).disposed(by: disposeBag)
-        
-        input.modelDivideCount
+    }
+    
+    func bindDivideCount(_ divideCount: Observable<Int>, _ disposeBag: DisposeBag) {
+        divideCount
             .subscribe(onNext: { [weak self] modelDivideCount in
                 guard let self else { return }
                 self.modelDivideCount = modelDivideCount
             }).disposed(by: disposeBag)
-        
-        input.completeButtonTapEvent
+    }
+    
+    func bindCompleteEvent(_ completeEvent: Observable<Void>, _ disposeBag: DisposeBag) {
+        completeEvent
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 if let modelTitle = self.modelTitle {

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
@@ -41,22 +41,14 @@ final class BlockEditViewModel {
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let editUseCaseInput = BlockEditUseCase.Input(modelEditEvent: self.completeButtonTapEvent)
-        let editUSeCaseOutput = blockEditUseCase.transform(input: editUseCaseInput,
+        let editUseCaseOutput = blockEditUseCase.transform(input: editUseCaseInput,
                                                            disposeBag: disposeBag)
-        let output = Output(isEditSuccess: editUSeCaseOutput.isEditSuccess)
+        let output = Output(isEditSuccess: editUseCaseOutput.isEditSuccess)
         
         bindModelTitle(input.modelTitle, disposeBag)
         bindDivideCount(input.modelDivideCount, disposeBag)
         bindCompleteEvent(input.completeButtonTapEvent, disposeBag)
-        
-        editUSeCaseOutput.isEditSuccess
-            .subscribe(onNext: { [weak self] isSuccess in
-                guard let self else { return }
-                if isSuccess {
-                    self.fetchRefreshDelegate?.refresh()
-                    self.editReflectDelegate?.reflect(self.originModel)
-                }
-            }).disposed(by: disposeBag)
+        bindEditSuccess(editUseCaseOutput.isEditSuccess, disposeBag)
         
         return output
     }
@@ -92,6 +84,17 @@ private extension BlockEditViewModel {
                 }
                 
                 self.completeButtonTapEvent.onNext(self.originModel)
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindEditSuccess(_ isEditSuccess: PublishSubject<Bool>, _ disposeBag: DisposeBag) {
+        isEditSuccess
+            .subscribe(onNext: { [weak self] isSuccess in
+                guard let self else { return }
+                if isSuccess {
+                    self.fetchRefreshDelegate?.refresh()
+                    self.editReflectDelegate?.reflect(self.originModel)
+                }
             }).disposed(by: disposeBag)
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockEditViewModel.swift
@@ -5,8 +5,6 @@
 //  Created by 이정민 on 2023/04/26.
 //
 
-import Foundation
-
 import RxSwift
 
 final class BlockEditViewModel {

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -7,10 +7,6 @@
 
 import RxSwift
 
-protocol FetchRefreshDelegate: AnyObject {
-    func refresh()
-}
-
 final class BlockListViewModel {
     struct Input {
         let addButtonEvent: Observable<Void>

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import RxCocoa
+import RxRelay
 import RxSwift
 
 final class BlockListViewModel {
@@ -17,7 +18,7 @@ final class BlockListViewModel {
     
     struct Output {
         let blockModelArray: BehaviorSubject<[BlockModel]> = .init(value: [])
-        let isDeleteSuccess: PublishSubject<Bool> = .init()
+        let isDeleteSuccess: PublishRelay<Bool> = .init()
     }
     
     private var blockFetchUseCase: BlockFetchUseCase
@@ -45,6 +46,16 @@ final class BlockListViewModel {
         fetchUseCaseOutput.modelArrayObservable
             .bind(to: output.blockModelArray)
             .disposed(by: disposeBag)
+        
+        deleteUseCaseOutput.isDeleteSuccess
+            .subscribe(onNext: { [weak self] isSuccess in
+                guard let self = self else { return }
+                if isSuccess {
+                    self.refresh()
+                }
+                
+                output.isDeleteSuccess.accept(isSuccess)
+            }).disposed(by: disposeBag)
         
         deleteUseCaseOutput.isDeleteSuccess
             .bind(to: output.isDeleteSuccess)

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -47,27 +47,23 @@ final class BlockListViewModel {
             .bind(to: output.blockModelArray)
             .disposed(by: disposeBag)
         
-        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, disposeBag)
+        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, to: output.isDeleteSuccess, disposeBag)
         bindAddButton(input.addButtonEvent, disposeBag: disposeBag)
         
         return output
     }
 }
 
-extension BlockListViewModel: FetchRefreshDelegate {
-    func refresh() {
-        modelFetchEvent.onNext(())
-    }
-}
-
 private extension BlockListViewModel {
-    func bindDeleteSuccess(_ isDeleteSuccess: PublishSubject<Bool>, _ disposeBag: DisposeBag) {
-        isDeleteSuccess
+    func bindDeleteSuccess(_ deleteEvent: PublishSubject<Bool>, to isDeleteSuccess: PublishRelay<Bool>, _ disposeBag: DisposeBag) {
+        deleteEvent
             .subscribe(onNext: { [weak self] isSuccess in
                 guard let self = self else { return }
                 if isSuccess {
                     self.refresh()
                 }
+                
+                isDeleteSuccess.accept(isSuccess)
             }).disposed(by: disposeBag)
     }
     
@@ -76,5 +72,11 @@ private extension BlockListViewModel {
             .subscribe(onNext: {
                 // coordinator push to createViewModel by 'push(fetchRefreshDelegate: self)' function
             }).disposed(by: disposeBag)
+    }
+}
+
+extension BlockListViewModel: FetchRefreshDelegate {
+    func refresh() {
+        modelFetchEvent.onNext(())
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -7,6 +7,10 @@
 
 import RxSwift
 
+protocol FetchRefreshDelegate: AnyObject {
+    func refresh()
+}
+
 final class BlockListViewModel {
     struct Input {
         let addButtonEvent: Observable<Void>
@@ -51,7 +55,13 @@ final class BlockListViewModel {
     private func bindAddButton(_ addButtonEvent: Observable<Void>, disposeBag: DisposeBag) {
         addButtonEvent
             .subscribe(onNext: {
-                // coordinator push to createViewModel by 'push(self.modelFetchEvent)' function
+                // coordinator push to createViewModel by 'push(fetchRefreshDelegate: self)' function
             }).disposed(by: disposeBag)
+    }
+}
+
+extension BlockListViewModel: FetchRefreshDelegate {
+    func refresh() {
+        modelFetchEvent.onNext(())
     }
 }

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -47,30 +47,10 @@ final class BlockListViewModel {
             .bind(to: output.blockModelArray)
             .disposed(by: disposeBag)
         
-        deleteUseCaseOutput.isDeleteSuccess
-            .subscribe(onNext: { [weak self] isSuccess in
-                guard let self = self else { return }
-                if isSuccess {
-                    self.refresh()
-                }
-                
-                output.isDeleteSuccess.accept(isSuccess)
-            }).disposed(by: disposeBag)
-        
-        deleteUseCaseOutput.isDeleteSuccess
-            .bind(to: output.isDeleteSuccess)
-            .disposed(by: disposeBag)
-        
+        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, disposeBag)
         bindAddButton(input.addButtonEvent, disposeBag: disposeBag)
         
         return output
-    }
-    
-    private func bindAddButton(_ addButtonEvent: Observable<Void>, disposeBag: DisposeBag) {
-        addButtonEvent
-            .subscribe(onNext: {
-                // coordinator push to createViewModel by 'push(fetchRefreshDelegate: self)' function
-            }).disposed(by: disposeBag)
     }
 }
 
@@ -79,3 +59,23 @@ extension BlockListViewModel: FetchRefreshDelegate {
         modelFetchEvent.onNext(())
     }
 }
+
+private extension BlockListViewModel {
+    func bindDeleteSuccess(_ isDeleteSuccess: PublishSubject<Bool>, _ disposeBag: DisposeBag) {
+        isDeleteSuccess
+            .subscribe(onNext: { [weak self] isSuccess in
+                guard let self = self else { return }
+                if isSuccess {
+                    self.refresh()
+                }
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindAddButton(_ addButtonEvent: Observable<Void>, disposeBag: DisposeBag) {
+        addButtonEvent
+            .subscribe(onNext: {
+                // coordinator push to createViewModel by 'push(fetchRefreshDelegate: self)' function
+            }).disposed(by: disposeBag)
+    }
+}
+

--- a/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/BlockListViewModel.swift
@@ -78,4 +78,3 @@ private extension BlockListViewModel {
             }).disposed(by: disposeBag)
     }
 }
-

--- a/Tempus/Presentation/BlockScene/ViewModel/Protocol/FetchRefreshDelegate.swift
+++ b/Tempus/Presentation/BlockScene/ViewModel/Protocol/FetchRefreshDelegate.swift
@@ -1,0 +1,10 @@
+//
+//  FetchRefreshDelegate.swift
+//  Tempus
+//
+//  Created by 이정민 on 2023/04/28.
+//
+
+protocol FetchRefreshDelegate: AnyObject {
+    func refresh()
+}

--- a/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
+++ b/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
@@ -5,6 +5,8 @@
 //  Created by 이정민 on 2023/04/28.
 //
 
+import RxCocoa
+import RxRelay
 import RxSwift
 
 final class DailyListViewModel {
@@ -15,7 +17,63 @@ final class DailyListViewModel {
     }
     
     struct Output {
-        let dailyModelArray: Observable<[DailyModel]>
-        let isDeleteSuccess: Observable<Bool>
+        let dailyModelArray: BehaviorSubject<[DailyModel]> = .init(value: [])
+        let isDeleteSuccess: PublishRelay<Bool> = .init()
+    }
+    
+    private var dailyFetchUseCase: DailyFetchUseCase
+    private var dailyDeleteUseCase: DailyDeleteUseCase
+    
+    private var modelFetchEvent: PublishSubject<Void>!
+    
+    init(repository: DataManagerRepository) {
+        self.dailyFetchUseCase = .init(repository: repository)
+        self.dailyDeleteUseCase = .init(repository: repository)
+    }
+    
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        self.modelFetchEvent = input.modelFetchEvent
+        
+        let fetchUseCaseInput = DailyFetchUseCase.Input(modelFetchEvent: input.modelFetchEvent)
+        let fetchUseCaseOutput = dailyFetchUseCase.transform(input: fetchUseCaseInput,
+                                                             disposeBag: disposeBag)
+        
+        let deleteUseCaseInput = DailyDeleteUseCase.Input(modelDeleteEvent: input.modelDeleteEvent)
+        let deleteUseCaseOutput = dailyDeleteUseCase.transform(input: deleteUseCaseInput,
+                                                               disposeBag: disposeBag)
+        fetchUseCaseOutput.modelArrayObservable
+            .bind(to: output.dailyModelArray)
+            .disposed(by: disposeBag)
+        
+        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, disposeBag)
+        bindAddButton(input.addButtonEvent, disposeBag: disposeBag)
+        
+        return output
+    }
+}
+
+private extension DailyListViewModel {
+    func bindDeleteSuccess(_ isDeleteSuccess: PublishSubject<Bool>, _ disposeBag: DisposeBag) {
+        isDeleteSuccess
+            .subscribe(onNext: { [weak self] isSuccess in
+                guard let self = self else { return }
+                if isSuccess {
+                    self.refresh()
+                }
+            }).disposed(by: disposeBag)
+    }
+    
+    func bindAddButton(_ addButtonEvent: Observable<Void>, disposeBag: DisposeBag) {
+        addButtonEvent
+            .subscribe(onNext: {
+                // coordinator push to createViewModel by 'push(fetchRefreshDelegate: self)' function
+            }).disposed(by: disposeBag)
+    }
+}
+
+extension DailyListViewModel: FetchRefreshDelegate {
+    func refresh() {
+        modelFetchEvent.onNext(())
     }
 }

--- a/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
+++ b/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
@@ -46,7 +46,7 @@ final class DailyListViewModel {
             .bind(to: output.dailyModelArray)
             .disposed(by: disposeBag)
         
-        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, disposeBag)
+        bindDeleteSuccess(deleteUseCaseOutput.isDeleteSuccess, to: output.isDeleteSuccess, disposeBag)
         bindAddButton(input.addButtonEvent, disposeBag: disposeBag)
         
         return output
@@ -54,13 +54,15 @@ final class DailyListViewModel {
 }
 
 private extension DailyListViewModel {
-    func bindDeleteSuccess(_ isDeleteSuccess: PublishSubject<Bool>, _ disposeBag: DisposeBag) {
-        isDeleteSuccess
+    func bindDeleteSuccess(_ deleteEvent: PublishSubject<Bool>, to isDeleteSuccess: PublishRelay<Bool>, _ disposeBag: DisposeBag) {
+        deleteEvent
             .subscribe(onNext: { [weak self] isSuccess in
                 guard let self = self else { return }
                 if isSuccess {
                     self.refresh()
                 }
+                
+                isDeleteSuccess.accept(isSuccess)
             }).disposed(by: disposeBag)
     }
     

--- a/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
+++ b/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  DailyListViewModel.swift
+//  Tempus
+//
+//  Created by 이정민 on 2023/04/28.
+//
+
+import RxSwift
+
+final class DailyListViewModel {
+    struct Input {
+        let addButtonEvent: Observable<Void>
+        let modelDeleteEvent: Observable<DailyModel>
+        let modelFetchEvent: PublishSubject<Void>
+    }
+    
+    struct Output {
+        let blockModelArray: Observable<[DailyModel]>
+        let isDeleteSuccess: Observable<Bool>
+    }
+}

--- a/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
+++ b/Tempus/Presentation/DailyScene/ViewModel/DailyListViewModel.swift
@@ -15,7 +15,7 @@ final class DailyListViewModel {
     }
     
     struct Output {
-        let blockModelArray: Observable<[DailyModel]>
+        let dailyModelArray: Observable<[DailyModel]>
         let isDeleteSuccess: Observable<Bool>
     }
 }

--- a/Tempus/Presentation/Utils/EditReflectDelegate.swift
+++ b/Tempus/Presentation/Utils/EditReflectDelegate.swift
@@ -5,6 +5,6 @@
 //  Created by 이정민 on 2023/04/25.
 //
 
-protocol EditReflectDelegate {
+protocol EditReflectDelegate: AnyObject {
     func reflect(_ model: Mode)
 }

--- a/TempusTests/UseCaseTests/BlockUseCaseTests/BlockCreateUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/BlockUseCaseTests/BlockCreateUseCaseTest.swift
@@ -32,7 +32,7 @@ final class BlockCreateUseCaseTest: XCTestCase {
         let fetchEvent: PublishSubject<Void> = .init()
         let createEvent: PublishSubject<BlockModel> = .init()
         
-        let input = BlockCreateUseCase.Input(modelFetchEvent: fetchEvent, modelCreate: createEvent)
+        let input = BlockCreateUseCase.Input(modelCreate: createEvent)
         let output = blockCreateUseCase.transform(input: input, disposeBag: disposeBag)
         
         output.isCreateSuccess

--- a/TempusTests/UseCaseTests/BlockUseCaseTests/BlockDeleteUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/BlockUseCaseTests/BlockDeleteUseCaseTest.swift
@@ -33,7 +33,7 @@ final class BlockDeleteUseCaseTest: XCTestCase {
         let fetchEvent: PublishSubject<Void> = .init()
         let createEvent: PublishSubject<BlockModel> = .init()
         
-        let createInput = BlockCreateUseCase.Input(modelFetchEvent: fetchEvent, modelCreate: createEvent)
+        let createInput = BlockCreateUseCase.Input(modelCreate: createEvent)
         let createOutput = blockCreateUseCase.transform(input: createInput, disposeBag: disposeBag)
         
         createOutput.isCreateSuccess
@@ -44,7 +44,7 @@ final class BlockDeleteUseCaseTest: XCTestCase {
         
         // Act, Assert
         let deleteEvent: PublishSubject<BlockModel> = .init()
-        let deleteInput = BlockDeleteUseCase.Input(modelDeleteEvent: deleteEvent, modelFetchEvent: fetchEvent)
+        let deleteInput = BlockDeleteUseCase.Input(modelDeleteEvent: deleteEvent)
         let deleteOutput = blockDeleteUseCase.transform(input: deleteInput, disposeBag: disposeBag)
         
         deleteOutput.isDeleteSuccess

--- a/TempusTests/UseCaseTests/BlockUseCaseTests/BlockEditUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/BlockUseCaseTests/BlockEditUseCaseTest.swift
@@ -28,7 +28,7 @@ final class BlockEditUseCaseTest: XCTestCase {
         modelFetchEvent = .init()
         disposeBag = .init()
         
-        editUseCaseInput = .init(modelEditEvent: modelEditEvent, modelFetchEvent: modelFetchEvent)
+        editUseCaseInput = .init(modelEditEvent: modelEditEvent)
         editUseCaseOutput = blockEditUseCase.transform(input: editUseCaseInput, disposeBag: disposeBag)
     }
 

--- a/TempusTests/UseCaseTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
@@ -33,7 +33,7 @@ final class BlockFetchUseCaseTest: XCTestCase {
         let fetchEvent: PublishSubject<Void> = .init()
         let createEvent: PublishSubject<BlockModel> = .init()
         
-        let createInput = BlockCreateUseCase.Input(modelFetchEvent: fetchEvent, modelCreate: createEvent)
+        let createInput = BlockCreateUseCase.Input(modelCreate: createEvent)
         let createOutput = blockCreateUseCase.transform(input: createInput, disposeBag: disposeBag)
         
         createOutput.isCreateSuccess

--- a/TempusTests/UseCaseTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/BlockUseCaseTests/BlockFetchUseCaseTest.swift
@@ -10,14 +10,12 @@ import XCTest
 import RxSwift
 
 final class BlockFetchUseCaseTest: XCTestCase {
-    var blockCreateUseCase: BlockCreateUseCase!
     var blockFetchUseCase: BlockFetchUseCase!
     var coreDataRepositoryMock: DataManagerRepositoryMock!
     var disposeBag: DisposeBag!
     
     override func setUpWithError() throws {
         coreDataRepositoryMock = DataManagerRepositoryMock()
-        blockCreateUseCase = BlockCreateUseCase(repository: coreDataRepositoryMock)
         blockFetchUseCase = BlockFetchUseCase(repository: coreDataRepositoryMock)
         disposeBag = DisposeBag()
     }
@@ -29,20 +27,11 @@ final class BlockFetchUseCaseTest: XCTestCase {
         let divideCount = 6
         let model = BlockModel(id: id, title: title, divideCount: divideCount)
         let expectation = XCTestExpectation(description: "fetch_usecase_test")
-        
-        let fetchEvent: PublishSubject<Void> = .init()
-        let createEvent: PublishSubject<BlockModel> = .init()
-        
-        let createInput = BlockCreateUseCase.Input(modelCreate: createEvent)
-        let createOutput = blockCreateUseCase.transform(input: createInput, disposeBag: disposeBag)
-        
-        createOutput.isCreateSuccess
-            .subscribe(onNext: { isSuccess in
-                XCTAssertEqual(isSuccess, true)
-            }).disposed(by: disposeBag)
-        createEvent.onNext(model)
+                
+        try! coreDataRepositoryMock.create(model)
         
         // Act, Assert
+        let fetchEvent: PublishSubject<Void> = .init()
         let fetchInput = BlockFetchUseCase.Input(modelFetchEvent: fetchEvent)
         let fetchOutput = blockFetchUseCase.transform(input: fetchInput, disposeBag: disposeBag)
         

--- a/TempusTests/UseCaseTests/DailyUseCaseTests/DailyDeleteUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/DailyUseCaseTests/DailyDeleteUseCaseTest.swift
@@ -11,7 +11,6 @@ import RxSwift
 
 final class DailyDeleteUseCaseTest: XCTestCase {
     var repository: DataManagerRepositoryMock!
-    var createUseCase: DailyCreateUseCase!
     var deleteUseCase: DailyDeleteUseCase!
     var disposeBag: DisposeBag!
     

--- a/TempusTests/UseCaseTests/DailyUseCaseTests/DailyDeleteUseCaseTest.swift
+++ b/TempusTests/UseCaseTests/DailyUseCaseTests/DailyDeleteUseCaseTest.swift
@@ -7,19 +7,23 @@
 
 import XCTest
 
+import RxSwift
+
 final class DailyDeleteUseCaseTest: XCTestCase {
     var repository: DataManagerRepositoryMock!
     var createUseCase: DailyCreateUseCase!
     var deleteUseCase: DailyDeleteUseCase!
+    var disposeBag: DisposeBag!
     
     override func setUpWithError() throws {
         repository = DataManagerRepositoryMock()
-        createUseCase = DailyCreateUseCase(repository: repository)
         deleteUseCase = DailyDeleteUseCase(repository: repository)
+        disposeBag = .init()
     }
     
     func test_delete_is_success() {
         // Arrange
+        let expectation = XCTestExpectation(description: "delete_test_isSuccess")
         let id = UUID()
         let title = "testTitle"
         let startTime: Double = 123456
@@ -32,15 +36,25 @@ final class DailyDeleteUseCaseTest: XCTestCase {
                                repeatCount: repeatCount,
                                focusTime: focusTime,
                                breakTime: breakTime)
-        try! createUseCase.execute(model: model) {}
+        try! repository.create(model)
+        XCTAssertNotNil(repository.dailyModel)
         
-        // Act, Assert
-        do {
-            try deleteUseCase.execute(model: model) {}
-            XCTAssertNil(repository.dailyModel)
-        } catch {
-            XCTFail()
-        }
+        // Act
+        let deleteEvent: PublishSubject<DailyModel> = .init()
+        let deleteUseCaseInput = DailyDeleteUseCase.Input(modelDeleteEvent: deleteEvent)
+        let deleteUseCaseOutput = deleteUseCase.transform(input: deleteUseCaseInput, disposeBag: disposeBag)
+        
+        deleteUseCaseOutput.isDeleteSuccess
+            .subscribe(onNext: { isSuccess in
+                XCTAssertTrue(isSuccess)
+                expectation.fulfill()
+            }).disposed(by: disposeBag)
+        
+        deleteEvent.onNext(model)
+        
+        // Assert
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(repository.dailyModel)
     }
     
 }

--- a/TempusTests/ViewModelTests/BlockSceneTests/BlockCreateViewModelTest.swift
+++ b/TempusTests/ViewModelTests/BlockSceneTests/BlockCreateViewModelTest.swift
@@ -11,17 +11,26 @@ import RxSwift
 
 final class BlockCreateViewModelTest: XCTestCase {
     var repositoryMock: DataManagerRepositoryMock!
-    var modelFetchEvent: PublishSubject<Void>!
     var completeEvent: PublishSubject<CompleteAlert>!
-    var disposeBag: DisposeBag!
+    var blockListViewModel: BlockListViewModel!
+    
     var blockCreateViewModel: BlockCreateViewModel!
+    var disposeBag: DisposeBag!
+    var listViewModelInput: BlockListViewModel.Input!
+    var listViewModelOutput: BlockListViewModel.Output!
     
     override func setUpWithError() throws {
         repositoryMock = .init()
-        modelFetchEvent = .init()
         completeEvent = .init()
+        blockListViewModel = .init(repository: repositoryMock)
+        blockCreateViewModel = .init(repository: repositoryMock,
+                                     fetchRefreshDelegate: blockListViewModel)
         disposeBag = .init()
-        blockCreateViewModel = .init(repository: repositoryMock, modelFetchEvent: modelFetchEvent)
+        
+        listViewModelInput = .init(addButtonEvent: PublishSubject<Void>(),
+                                   modelDeleteEvent: PublishSubject<BlockModel>(),
+                                   modelFetchEvent: PublishSubject<Void>())
+        listViewModelOutput = blockListViewModel.transform(input: listViewModelInput, disposeBag: disposeBag)
     }
     
     func test_create_is_success() {
@@ -38,7 +47,7 @@ final class BlockCreateViewModelTest: XCTestCase {
         
         let output = blockCreateViewModel.transform(input: input, disposeBag: disposeBag)
         
-        output.isCreateSucess
+        output.isCreateSuccess
             .subscribe(onNext: { isSuccess in
                 if isSuccess {
                     expectation.fulfill()

--- a/TempusTests/ViewModelTests/BlockSceneTests/BlockEditViewModelTest.swift
+++ b/TempusTests/ViewModelTests/BlockSceneTests/BlockEditViewModelTest.swift
@@ -12,9 +12,15 @@ import RxSwift
 final class BlockEditViewModelTest: XCTestCase {
     var repositoryMock: DataManagerRepositoryMock!
     var originModel: BlockModel!
-    
-    var modelFetchEvent: PublishSubject<Void>!
     var disposeBag: DisposeBag!
+    
+    var blockListViewModel: BlockListViewModel!
+    var listViewModelInput: BlockListViewModel.Input!
+    var listViewModelOutput: BlockListViewModel.Output!
+    
+    var blockDetailViewModel: BlockDetailViewModel!
+    var detailViewModelInput: BlockDetailViewModel.Input!
+    var detailViewModelOutput: BlockDetailViewModel.Output!
     
     var blockEditViewModel: BlockEditViewModel!
     
@@ -28,13 +34,27 @@ final class BlockEditViewModelTest: XCTestCase {
     override func setUpWithError() throws {
         repositoryMock = .init()
         originModel = .init(id: UUID(), title: "testTitle", divideCount: 4)
-        
-        modelFetchEvent = .init()
         disposeBag = .init()
+        
+        blockListViewModel = .init(repository: repositoryMock)
+        listViewModelInput = .init(addButtonEvent: PublishSubject<Void>(),
+                                   modelDeleteEvent: PublishSubject<BlockModel>(),
+                                   modelFetchEvent: PublishSubject<Void>())
+        listViewModelOutput = blockListViewModel.transform(input: listViewModelInput,
+                                                           disposeBag: disposeBag)
+
+        blockDetailViewModel = .init(originModel: originModel)
+        detailViewModelInput = BlockDetailViewModel.Input(
+            startButtonTapEvent: PublishSubject<Void>(),
+            editButtonTapEvent: PublishSubject<Void>(),
+            cancelButtonTapEvent: PublishSubject<Void>())
+        detailViewModelOutput = blockDetailViewModel.transform(input: detailViewModelInput,
+                                                               disposeBag: disposeBag)
         
         blockEditViewModel = .init(originModel: originModel,
                                    repository: repositoryMock,
-                                   modelFetchEvent: modelFetchEvent)
+                                   fetchRefreshDelegate: blockListViewModel,
+                                   editReflectDelegate: blockDetailViewModel)
         
         modelTitle = .init()
         modelDivideCount = .init()

--- a/TempusTests/ViewModelTests/BlockSceneTests/BlockListViewModelTest.swift
+++ b/TempusTests/ViewModelTests/BlockSceneTests/BlockListViewModelTest.swift
@@ -66,7 +66,8 @@ final class BlockListViewModelTest: XCTestCase {
 
     func test_delete_event_emit_then_fetch_success() {
         // Arrange
-        let expectation = XCTestExpectation(description: "delete_event_test_description")
+        let fetchExpectation = XCTestExpectation(description: "fetch_is_success")
+        let deleteExpectation = XCTestExpectation(description: "delete_is_success")
         let testModel = BlockModel(id: UUID(), title: "testTitle", divideCount: 4)
         var resultModel: [BlockModel] = []
         
@@ -79,13 +80,14 @@ final class BlockListViewModelTest: XCTestCase {
         output.isDeleteSuccess
             .subscribe(onNext: { isSuccess in
                 XCTAssertTrue(isSuccess)
+                deleteExpectation.fulfill()
             }).disposed(by: disposeBag)
         
         output.blockModelArray
             .subscribe(onNext: { models in
                 resultModel = models
                 if models.isEmpty {
-                    expectation.fulfill()
+                    fetchExpectation.fulfill()
                 }
             }).disposed(by: disposeBag)
         
@@ -95,7 +97,7 @@ final class BlockListViewModelTest: XCTestCase {
         modelDeleteEvent.onNext(testModel)
         
         // Assert
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [fetchExpectation, deleteExpectation], timeout: 2.0)
         XCTAssertTrue(resultModel.isEmpty)
     }
 }

--- a/TempusTests/ViewModelTests/DailySceneTests/DailyListViewModelTest.swift
+++ b/TempusTests/ViewModelTests/DailySceneTests/DailyListViewModelTest.swift
@@ -1,0 +1,56 @@
+//
+//  DailyListViewModelTest.swift
+//  TempusTests
+//
+//  Created by 이정민 on 2023/04/29.
+//
+
+import XCTest
+
+import RxSwift
+
+final class DailyListViewModelTest: XCTestCase {
+    var disposeBag: DisposeBag!
+    var repositoryMock: DataManagerRepositoryMock!
+    var dailyListViewModel: DailyListViewModel!
+    var dailyListViewModelInput: DailyListViewModel.Input!
+    var dailyListViewModelOutput: DailyListViewModel.Output!
+    
+    override func setUpWithError() throws {
+        disposeBag = .init()
+        repositoryMock = .init()
+        dailyListViewModel = .init(repository: repositoryMock)
+        dailyListViewModelInput = .init(addButtonEvent: PublishSubject<Void>(),
+                                        modelDeleteEvent: PublishSubject<DailyModel>(),
+                                        modelFetchEvent: PublishSubject<Void>())
+        dailyListViewModelOutput = dailyListViewModel.transform(input: dailyListViewModelInput,
+                                                                disposeBag: disposeBag)
+    }
+    
+    func test_model_fetch_is_success() {
+        // Arrange
+        let expectation = XCTestExpectation(description: "fetch_test_is_success")
+        let model = DailyModel(id: UUID(),
+                               title: "testTitle",
+                               startTime: 100,
+                               repeatCount: 4,
+                               focusTime: 1200,
+                               breakTime: 300)
+        var resultModels: [DailyModel] = []
+        
+        try! repositoryMock.create(model)
+        
+        // Act
+        dailyListViewModelOutput.dailyModelArray
+            .subscribe(onNext: { models in
+                resultModels = models
+                expectation.fulfill()
+            }).disposed(by: disposeBag)
+        
+        dailyListViewModelInput.modelFetchEvent.onNext(())
+        
+        // Assert
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(resultModels.first?.id, model.id)
+    }
+}


### PR DESCRIPTION
Closed #65 

### 구현내용
- DailyListViewModel Input, Output
- BlockScene의 구조를 그리며 refactoring
  - 아래 그림처럼 Create, Edit, Delete 시 fetchEvent를 보내서 변경을 refresh 하도록 했었지만 오히려 구조를 알기 어렵게 만들어서 복잡하게 되고 Input, Output을 그렇게 사용하는 것은 옳지 않고 타입 사이에 1:1로 사용되어야 하는 것이 옳다고 생각되어 변경.
- Output 생성 시 내부 변수로 가지고 있지 않고 struct 생성 시 가지도록 수정.
  - ARC가 0이되어 없어지지 않을까 했으나 disposeBag에 함께 묶여 ARC가 0이 되지 않음.
- DailyListViewModel 에서 사용하는 DeleteUseCase, FetchUseCase를 Input, Output 방식으로 수정 및 test
- DailyListViewModel test

<img width="1369" alt="스크린샷 2023-04-29 오전 6 36 51" src="https://user-images.githubusercontent.com/82566116/235258387-a138eb33-45f5-41a7-886e-bead22f48591.png">

### 필수체크
- [x] 정상적인 빌드
- [x] 단위테스트 